### PR TITLE
Improve continuum fitting by masking absorption dips during iterative coefficient fitting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ nmfqsofit --config config_example.yml
 ## config.yml file will contain all the user-defined arguments to run the script
 ```
 
+> **Important — override precedence:** when `--config` is provided, **every key in the YAML file overwrites the corresponding CLI argument**, including values you explicitly passed on the command line. CLI arguments only take effect for keys that are *absent* from the config file. To mix both, omit a key from the YAML and pass it on the command line instead.
+
 See `config_example.yml` file to see how a parameter config file will look like.
 
 

--- a/README.md
+++ b/README.md
@@ -20,27 +20,25 @@
 nmfqsofit: Quasar Continuum Fitter
 ============
 
-**An Efficient, Fast, and Reliable Automated Continuum Fitter for Low-Resolution Quasar Spectra Using Non-negative Matrix Factorization (NMF)**
-
-`nmfqsofit` is a fast, modular, and scalable Python package for estimating quasar continua using precomputed NMF eigenspectra. It supports both NNLS-based fitting vectorized NMF coefficient estimation, works with SDSS/DESI/4MOST/WEAVE-like spectra, and is designed for large spectroscopic surveys and HPC environments.
+`nmfqsofit` is a Python package for estimating quasar continua using precomputed Nonnegative matrix factorization (NMF) eigenspectra. It supports both Nonnegative least square (NNLS) and NMF coefficient fitting. It is generic enough to work with any kind of spectra. Though it has been currently only tested on large spectroscopic surveys like SDSS and DESI. It is well designed for both local and HPC environments.
 
 ---
 
 ## Features
 
-- **NMF-based quasar continuum modeling** – Fits coefficients using Non-negative Matrix Factorization (slower)
-- **NNLS alternative** – Optionally use Non-Negative Least Squares for coefficient fitting (faster)
+- **NMF-based quasar continuum modeling** – Fits coefficients using Nonnegative Matrix Factorization (slower)
+- **NNLS alternative** – Optionally use Nonnegative Least Squares for coefficient fitting (faster)
+- **Iterative absorption rejection** – During coefficient fitting, pixels with low flux (absorption troughs) are iteratively sigma-clipped so they do not pull the continuum downward
 - **Spectrum normalization & scaling** – Fits the normalized spectrum and automatically scales the continuum back to the observed frame  
 - **Flexible eigenvector interpolation** – Interpolates NMF eigenvectors to observed frame using user-provided interpolation kind (e.g., 'linear', 'cubic', 'nearest')  
 - **Multiple redshift-dependent eigenspectra support** – Handles multiple redshift bins with automatic selection based on quasar redshift  
 - **Automatic best-eigenset selection** – Selects the eigenset with minimum cost when multiple bins are valid  
-- **Median filtering flexibility** – Performs iterative smoothing on continuum model to improve reduced chi2 by removing small and intermediate scale fluctuations  
-- **Comprehensive logging framework** – Structured logging with python log levels for observability  
+- **Median filtering correction** – Applies iterative median-filter smoothing to the continuum to remove small and intermediate-scale calibration residuals  
 - **Efficient parallel processing** – Multiprocessing-based batch fitting optimized for HPC environments  
 - **Flexible eigenspectra loading** – Load from single FITS files or entire directories  
-- **Clean FITS I/O** – Well-structured input/output with validated HDU structure  
-- **Modular and extensible design** – Clear separation of concerns for easy extension  
+- **Clean FITS I/O** – Out of the box functions for input/output files with validated HDU structure  
 - **Unit tests included** – pytest-based test suite with integration tests 
+- **Logging** – All operations are logged with timestamps, function names, and line numbers.
 
 ---
 
@@ -54,7 +52,7 @@ nmfqsofit: Quasar Continuum Fitter
 
 ## Requirements
 
-- Python >= 3.9
+- Python >= 3.10
 - numpy
 - scipy
 - astropy
@@ -135,12 +133,13 @@ The pipeline automatically:
    - **Identify matching redshift bins** – Selects eigenspectra with redshift bins encompassing the quasar's redshift.
    - **Normalize spectrum** – Normalizes the observed spectrum to a reference continuum level.
    - **Interpolate eigenvectors** – Interpolates eigenspectra from eigenspectra wavelength grid to observed wavelength grid using user-specified interpolation kind (linear, cubic, etc.).
-   - **Fit coefficients** – Solves for NMF/NNLS coefficients on the normalized spectrum using scipy.optimize.nnls or NonnegMFPy.
+   - **Fit coefficients** – Solves for NMF/NNLS coefficients on the normalized spectrum using `scipy.optimize.nnls` or `NonnegMFPy`. Pixels with low flux relative to the model (absorption troughs) are iteratively sigma-clipped so they cannot bias the fit downward. The sigma threshold is estimated from emission-side residuals only.
    - **Scale back to observed frame** – Reconstructs the continuum in observed frame using the fitted coefficients and interpolated eigenvectors.
-   - **Select best eigenset** – If multiple redshift bins are valid, automatically selects the eigenset with minimum chi2 cost.
-4. **Apply median filtering correction** – Applies median-filter smoothing correction in the observed frame to remove intermediate and small scale continuum fluctuations.
-5. **Save results** – Writes coefficients, continuum, fit statistics, and metadata to output FITS file.
-6. **Comprehensive logging** – All operations are logged with timestamps, function names, and line numbers for debugging and monitoring.
+   - **Select best eigenset** – If multiple redshift bins are valid, automatically selects the eigenset with minimum $\chi^2$ cost.
+4. **Apply median filtering correction** – Applies median-filter smoothing correction in the observed frame to remove intermediate and small-scale calibration residuals. Absorption dips are pre-masked via a coarse median filter and MAD sigma-clip before the iterative smoothing loop, preventing them from entering the filter. The smoothed continuum is kept only if it reduces the chi2 over all pixels; otherwise the original continuum is retained.
+5. **Save results** – Writes coefficients, continuum, fit statistics, and metadata to the output FITS file.
+6. **Logging** – All operations are logged with timestamps, function names, and line numbers.
+
 
 ---
 
@@ -173,17 +172,22 @@ See `config_example.yml` file to see how a parameter config file will look like.
 
 ### Options
 
-- `--spectra-file`: Input FITS file with FLUX, IVAR, WAVELENGTH, and METADATA (with Z column)
-- `--eigenspectra`: Directory or single FITS file containing NMF eigenspectra
-- `--kernel-size`: Median filter kernel size for smoothing correction (default: 71)
-- `--method`: Fitting method – `nnls` (Non-Negative Least Squares) or `nmf` (Non-negative Matrix Factorization; default: `nnls`)
-- `--interp-kind`: Eigenvector interpolation method (`linear`, `cubic`, `quadratic`, etc.; default: `linear`)
-- `--ncpus`: Number of CPU processes for parallel fitting (default: 8)
-- `--maxiters`: Maximum iterations for NMF or NNLS solver (default: 200)
-- `--smoothing-niter`: number of maximum iteration for median filtering (default 3)
-- `--n-qso`: Number of QSOs to process – can be an integer (`100`), range (`1-1000`), or stepped range (`1-1000:10`)
-- `--output`: Output FITS filename
-- `--headers`: Optional FITS header keywords (e.g., `AUTHOR=Name SURVEY=Mission`)
+| CLI argument | Required / Optional | Description |
+|---|---|---|
+| `--spectra-file` | Required | Input FITS file with FLUX, IVAR, WAVELENGTH, and METADATA (with Z column) |
+| `--eigenspectra` | Required | Directory or single FITS file containing NMF eigenspectra |
+| `--output` | Required | Output FITS filename |
+| `--method` | Optional | Fitting method: `nnls` (Non-Negative Least Squares) or `nmf` (Non-negative Matrix Factorization); default: `nnls` |
+| `--interp-kind` | Optional | Eigenvector interpolation method (`linear`, `cubic`, `quadratic`, etc.); default: `linear` |
+| `--kernel-size` | Optional | Median filter kernel size for smoothing correction; default: `71` |
+| `--ncpus` | Optional | Number of CPU processes for parallel fitting; default: `4` |
+| `--maxiters` | Optional | Maximum iterations for NMF or NNLS solver; default: `200` |
+| `--smoothing-niter` | Optional | Maximum iterations for median filtering; default: `3` |
+| `--fit-niter` | Optional | Number of iterative sigma-rejection passes during coefficient fitting; default: `1` (set to `0` to disable) |
+| `--fit-nsigma` | Optional | Downward sigma threshold for absorption rejection during fitting; default: `3.0` |
+| `--n-qso` | Optional | Number of QSOs to process – integer (`100`), range (`1-1000`), or stepped range (`1-1000:10`) |
+| `--headers` | Optional | Extra FITS header keywords to write (e.g., `AUTHOR=Name SURVEY=Mission`) |
+| `--config` | Optional | Path to a YAML config file; values override all other CLI arguments |
 
 ### Using NMF (instead of NNLS)
 Replace `--method nnls` with `--method nmf`.
@@ -262,7 +266,7 @@ Contributions are welcome! Please submit a pull request or open an issue to disc
 Acknowledgements
 -----------
 
-The first crude version of the code was developed and written by me during my PhD with lots of suggestions from my PhD supervisors [Prof. Dr. Guinevere Kauffmann](https://www.mpa-garching.mpg.de/person/44092) and [Dr. Dylan Nelson](https://nelson.tng-project.org/). Over the years, it has evolved from a specialized script into the generic, community-ready framework it is today. I would like to extend my thanks to the VS Code AI agents, which were instrumental in refining the codebase. They provided invaluable assistance in documenting functions, logging details, optimizing logic, and expanding unit test coverage, helping to ensure the code is both robust and maintainable. The project logo was created from a continuum example generated by me, with assistance from ChatGPT-5.3.
+The first crude version of the code was developed and written by me during my PhD with lots of suggestions from my PhD supervisors [Prof. Dr. Guinevere Kauffmann](https://www.mpa-garching.mpg.de/person/44092) and [Dr. Dylan Nelson](https://nelson.tng-project.org/). Over the years, it has evolved from a specialized script into the generic, community-ready framework it is today. I would like to extend my thanks to the VS Code AI agents, which were instrumental in refining the codebase. They provided invaluable assistance in documenting functions, logging details, optimizing logic, and expanding unit test coverage, helping to ensure the code is both robust and maintainable. The project logo was created from a continuum example generated by me using ChatGPT.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ nmfqsofit: Quasar Continuum Fitter
 - **Spectrum normalization & scaling** – Fits the normalized spectrum and automatically scales the continuum back to the observed frame  
 - **Flexible eigenvector interpolation** – Interpolates NMF eigenvectors to observed frame using user-provided interpolation kind (e.g., 'linear', 'cubic', 'nearest')  
 - **Multiple redshift-dependent eigenspectra support** – Handles multiple redshift bins with automatic selection based on quasar redshift  
-- **Automatic best-eigenset selection** – Selects the eigenset with minimum cost when multiple bins are valid  
+- **Automatic best-eigenset selection** – When multiple redshift bins overlap, selects the eigenset whose rest-frame wavelength range has the most valid observed pixels (maximum spectral coverage), rather than using chi2 which can be biased by absorption  
 - **Median filtering correction** – Applies iterative median-filter smoothing to the continuum to remove small and intermediate-scale calibration residuals  
 - **Efficient parallel processing** – Multiprocessing-based batch fitting optimized for HPC environments  
 - **Flexible eigenspectra loading** – Load from single FITS files or entire directories  
@@ -121,7 +121,7 @@ The pipeline automatically:
 - Fits using all matching redshift bins  
 - Use either NMF or NNLS method to find continuum coefficients
 - Performs efficient smoothing to improve reduced chi2
-- Chooses the solution with minimum cost (i.e. reduced chi2) 
+- Chooses the solution with maximum spectral coverage (valid pixel count within the eigenset's rest-frame range) 
 - Logs detailed information about loaded eigenspectra (redshift bins, wavelength ranges, number of components)
 ---
 
@@ -135,7 +135,7 @@ The pipeline automatically:
    - **Interpolate eigenvectors** – Interpolates eigenspectra from eigenspectra wavelength grid to observed wavelength grid using user-specified interpolation kind (linear, cubic, etc.).
    - **Fit coefficients** – Solves for NMF/NNLS coefficients on the normalized spectrum using `scipy.optimize.nnls` or `NonnegMFPy`. Pixels with low flux relative to the model (absorption troughs) are iteratively sigma-clipped so they cannot bias the fit downward. The sigma threshold is estimated from emission-side residuals only.
    - **Scale back to observed frame** – Reconstructs the continuum in observed frame using the fitted coefficients and interpolated eigenvectors.
-   - **Select best eigenset** – If multiple redshift bins are valid, automatically selects the eigenset with minimum $\chi^2$ cost.
+   - **Select best eigenset** – If multiple redshift bins are valid, selects the eigenset whose rest-frame wavelength range covers the most valid observed pixels. This is more robust than chi2-based selection, which is biased downward when absorption features are present (a continuum that traces absorbers has artificially low chi2). The coverage criterion directly reflects how well the data constrain the coefficients.
 4. **Apply median filtering correction** – Applies median-filter smoothing correction in the observed frame to remove intermediate and small-scale calibration residuals. Absorption dips are pre-masked via a coarse median filter and MAD sigma-clip before the iterative smoothing loop, preventing them from entering the filter. The smoothed continuum is kept only if it reduces the chi2 over all pixels; otherwise the original continuum is retained.
 5. **Save results** – Writes coefficients, continuum, fit statistics, and metadata to the output FITS file.
 6. **Logging** – All operations are logged with timestamps, function names, and line numbers.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 [![github shields.io](https://img.shields.io/badge/GitHub-abhi0395%2Fnmfqsofit-blue.svg?style=flat)](https://github.com/abhi0395/nmfqsofit)
 [![github shields.io](https://img.shields.io/badge/GitHub-abhi0395%2Fnmfeigenspectra-pink.svg?style=flat)](https://github.com/abhi0395/nmfeigenspectra)
-[![arXiv-2504.20299](http://img.shields.io/badge/arXiv-2504.20299-orange.svg?style=flat)](https://arxiv.org/abs/2504.20299)
 [![arXiv-2103.15842](http://img.shields.io/badge/arXiv-2103.15842-orange.svg?style=flat)](https://arxiv.org/abs/2103.15842)
 [![arXiv-1612.06037](http://img.shields.io/badge/arXiv-1612.06037-orange.svg?style=flat)](https://arxiv.org/abs/1612.06037)
 [![codecov](https://codecov.io/gh/abhi0395/nmfqsofit/graph/badge.svg)](https://codecov.io/gh/abhi0395/nmfqsofit)
@@ -98,7 +97,7 @@ nmfqsofit --help
 
 The NMF eigenspectra are maintained in a separate [repository](https://github.com/abhi0395/nmfeigenspectra). This keeps the eigenspectra data independent from the `nmfqsofit` codebase, allowing both to evolve separately. Currently, the repository provides eigenspectra built from **SDSS DR14** and **DESI DR1** quasar spectra only. In the future, eigenspectra from additional surveys (e.g., 4MOST, WEAVE, HST, WAVES) will be added.
 
-Before running `nmfqsofit`, download the eigenspectra repository. It is recommeded to use tagged version to ensure reproducibility. 
+Before running `nmfqsofit`, download the eigenspectra repository. It is recommeded to use **tagged** version to ensure reproducibility. 
 
 ```bash
 git clone https://github.com/abhi0395/nmfeigenspectra.git
@@ -131,12 +130,12 @@ The pipeline automatically:
 2. **Load eigenspectra** – Loads NMF eigenspectra from a directory or single file. Eigenspectra are organized by redshift bins and wavelength ranges.
 3. **For each quasar**:
    - **Identify matching redshift bins** – Selects eigenspectra with redshift bins encompassing the quasar's redshift.
-   - **Normalize spectrum** – Normalizes the observed spectrum to a reference continuum level.
+   - **Normalize spectrum** – Normalizes the observed spectrum to a reference continuum level using header keywords in eigenspectra.
    - **Interpolate eigenvectors** – Interpolates eigenspectra from eigenspectra wavelength grid to observed wavelength grid using user-specified interpolation kind (linear, cubic, etc.).
    - **Fit coefficients** – Solves for NMF/NNLS coefficients on the normalized spectrum using `scipy.optimize.nnls` or `NonnegMFPy`. Pixels with low flux relative to the model (absorption troughs) are iteratively sigma-clipped so they cannot bias the fit downward. The sigma threshold is estimated from emission-side residuals only.
    - **Scale back to observed frame** – Reconstructs the continuum in observed frame using the fitted coefficients and interpolated eigenvectors.
    - **Select best eigenset** – If multiple redshift bins are valid, selects the eigenset whose rest-frame wavelength range covers the most valid observed pixels. This is more robust than chi2-based selection, which is biased downward when absorption features are present (a continuum that traces absorbers has artificially low chi2). The coverage criterion directly reflects how well the data constrain the coefficients.
-4. **Apply median filtering correction** – Applies median-filter smoothing correction in the observed frame to remove intermediate and small-scale calibration residuals. Absorption dips are pre-masked via a coarse median filter and MAD sigma-clip before the iterative smoothing loop, preventing them from entering the filter. The smoothed continuum is kept only if it reduces the chi2 over all pixels; otherwise the original continuum is retained.
+4. **Apply median filtering correction** – Applies median-filter smoothing correction in the observed frame to remove intermediate and small-scale calibration residuals. Absorption dips are pre-masked via MAD sigma-clip before the iterative smoothing loop, preventing them from entering the filter. The smoothed continuum is kept only if it reduces the chi2 over all pixels; otherwise the original continuum is retained.
 5. **Save results** – Writes coefficients, continuum, fit statistics, and metadata to the output FITS file.
 6. **Logging** – All operations are logged with timestamps, function names, and line numbers.
 
@@ -174,6 +173,7 @@ See `config_example.yml` file to see how a parameter config file will look like.
 
 | CLI argument | Required / Optional | Description |
 |---|---|---|
+| `--config` | Optional | Path to a YAML config file; values override all other CLI arguments |
 | `--spectra-file` | Required | Input FITS file with FLUX, IVAR, WAVELENGTH, and METADATA (with Z column) |
 | `--eigenspectra` | Required | Directory or single FITS file containing NMF eigenspectra |
 | `--output` | Required | Output FITS filename |
@@ -183,11 +183,10 @@ See `config_example.yml` file to see how a parameter config file will look like.
 | `--ncpus` | Optional | Number of CPU processes for parallel fitting; default: `4` |
 | `--maxiters` | Optional | Maximum iterations for NMF or NNLS solver; default: `200` |
 | `--smoothing-niter` | Optional | Maximum iterations for median filtering; default: `3` |
-| `--fit-niter` | Optional | Number of iterative sigma-rejection passes during coefficient fitting; default: `1` (set to `0` to disable) |
+| `--fit-niter` | Optional | Number of iterative sigma-rejection passes during coefficient fitting; default: `3` (set to `0` to disable) |
 | `--fit-nsigma` | Optional | Downward sigma threshold for absorption rejection during fitting; default: `3.0` |
 | `--n-qso` | Optional | Number of QSOs to process – integer (`100`), range (`1-1000`), or stepped range (`1-1000:10`) |
-| `--headers` | Optional | Extra FITS header keywords to write (e.g., `AUTHOR=Name SURVEY=Mission`) |
-| `--config` | Optional | Path to a YAML config file; values override all other CLI arguments |
+| `--headers` | Optional | Extra FITS header keywords to write (e.g., `AUTHOR=Name SURVEY=Survey`) |
 
 ### Using NMF (instead of NNLS)
 Replace `--method nnls` with `--method nmf`.
@@ -252,7 +251,7 @@ Citations
 
 If you use this code, please cite:
 
-- [Anand et al. 2025](https://arxiv.org/abs/2504.20299), Description of **nmfqsofit** and DESI DR1 continuum
+- [Anand et al. 2026 (in prep.)](https://github.com/abhi0395/nmfqsofit), Description of **nmfqsofit** and DESI DR1 continuum
 - [Anand et al. 2021](https://arxiv.org/abs/2103.15842), SDSS DR14 Eigenspectra
 - [Zhu 2016](https://arxiv.org/abs/1612.06037), Vectorized NMF implementation
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ nmfqsofit --help
 
 The NMF eigenspectra are maintained in a separate [repository](https://github.com/abhi0395/nmfeigenspectra). This keeps the eigenspectra data independent from the `nmfqsofit` codebase, allowing both to evolve separately. Currently, the repository provides eigenspectra built from **SDSS DR14** and **DESI DR1** quasar spectra only. In the future, eigenspectra from additional surveys (e.g., 4MOST, WEAVE, HST, WAVES) will be added.
 
-Before running `nmfqsofit`, download the eigenspectra repository. It is recommeded to use **tagged** version to ensure reproducibility. 
+Before running `nmfqsofit`, download the eigenspectra repository. It is recommended to use **tagged** version to ensure reproducibility. 
 
 ```bash
 git clone https://github.com/abhi0395/nmfeigenspectra.git
@@ -166,6 +166,7 @@ nmfqsofit \
   --spectra-file data/test_sdss_spectra.fits \
   --eigenspectra /path/to/nmfeigenspectra/sdss \
   --kernel-size 141 \
+  --kernel-small 71 \
   --method nnls \
   --interp-kind linear \
   --ncpus 8 \
@@ -194,12 +195,14 @@ See `config_example.yml` file to see how a parameter config file will look like.
 | `--output` | Required | Output FITS filename |
 | `--method` | Optional | Fitting method: `nnls` (Non-Negative Least Squares) or `nmf` (Non-negative Matrix Factorization); default: `nnls` |
 | `--interp-kind` | Optional | Eigenvector interpolation method (`linear`, `cubic`, `quadratic`, etc.); default: `linear` |
-| `--kernel-size` | Optional | Median filter kernel size for smoothing correction; default: `71` |
+| `--kernel-size` | Optional | Median filter kernel size for intermediate-scale smoothing correction (odd integer); default: `141` |
+| `--kernel-small` | Optional | Median filter kernel size for small-scale smoothing correction (odd integer); default: half of `--kernel-size` rounded up to the nearest odd integer |
 | `--ncpus` | Optional | Number of CPU processes for parallel fitting; default: `4` |
 | `--maxiters` | Optional | Maximum iterations for NMF or NNLS solver; default: `200` |
 | `--smoothing-niter` | Optional | Maximum iterations for median filtering; default: `3` |
 | `--fit-niter` | Optional | Number of iterative sigma-rejection passes during coefficient fitting; default: `3` (set to `0` to disable) |
-| `--fit-nsigma` | Optional | Downward sigma threshold for absorption rejection during fitting; default: `3.0` |
+| `--fit-nsigma` | Optional | Downward sigma threshold for absorption rejection during coefficient fitting; default: `3.0` |
+| `--smooth-nsigma` | Optional | Downward sigma threshold for absorption masking during smoothing correction; default: `3.0` |
 | `--n-qso` | Optional | Number of QSOs to process – integer (`100`), range (`1-1000`), or stepped range (`1-1000:10`) |
 | `--headers` | Optional | Extra FITS header keywords to write (e.g., `AUTHOR=Name SURVEY=Survey`) |
 

--- a/config_example.yml
+++ b/config_example.yml
@@ -15,6 +15,8 @@ kernel_size: 141
 method: nnls  # options: "nnls" or "nmf"
 maxiters: 200
 interp_kind: linear
+fit_niter: 3       # sigma-rejection iterations during coefficient fitting (0 = no rejection)
+fit_nsigma: 3.0    # sigma threshold for absorption masking during fitting
 
 # Optional headers as list
 headers:

--- a/config_example.yml
+++ b/config_example.yml
@@ -5,9 +5,7 @@
 #
 # IMPORTANT — override precedence:
 #   Every key present in this file OVERWRITES the corresponding CLI argument,
-#   even if that argument was explicitly provided on the command line.
 #   CLI arguments only take effect for keys that are absent from this file.
-#   To mix both, simply omit a key here and pass it on the command line.
 ################################
 
 spectra_file: /path/to/spectra.fits

--- a/config_example.yml
+++ b/config_example.yml
@@ -1,7 +1,13 @@
 # Example YAML config file for nmfqsofit
 # Copy this file, update the paths and parameters, then run:
-
+#
 #  nmfqsofit --config your_config.yml
+#
+# IMPORTANT — override precedence:
+#   Every key present in this file OVERWRITES the corresponding CLI argument,
+#   even if that argument was explicitly provided on the command line.
+#   CLI arguments only take effect for keys that are absent from this file.
+#   To mix both, simply omit a key here and pass it on the command line.
 ################################
 
 spectra_file: /path/to/spectra.fits
@@ -16,7 +22,9 @@ method: nnls  # options: "nnls" or "nmf"
 maxiters: 200
 interp_kind: linear
 fit_niter: 3       # sigma-rejection iterations during coefficient fitting (0 = no rejection)
-fit_nsigma: 3.0    # sigma threshold for absorption masking during fitting
+fit_nsigma: 3.0    # sigma threshold for absorption masking during coefficient fitting
+smooth_nsigma: 3.0 # sigma threshold for absorption masking during smoothing correction
+kernel_small: null # small-scale median filter kernel (null = auto: half of kernel_size, rounded up to odd)
 
 # Optional headers as list
 headers:

--- a/nmfqsofit/io.py
+++ b/nmfqsofit/io.py
@@ -1,6 +1,7 @@
 """
 This script contains functions to read, append and write fits files.
 """
+from fileinput import filename
 import os
 import re
 import time
@@ -188,9 +189,6 @@ def write_continuum(
     )
     hdul.writeto(str(filename), overwrite=True)
 
-    logger.info(f"Data written to {filename}")
-    elapsed_time = time.time() - start_time
-    logger.info(f"Time taken to write {filename}: {elapsed_time:.2f} s")
 
 class QSOSpecRead:
     """
@@ -233,7 +231,8 @@ class QSOSpecRead:
             self.fits_file, self.index
         )
         if self.verbose:
-            elapsed(start_time, f"Time taken to read {self.fits_file}", use_logger=True)
+            elapsed_time = time.time() - start_time
+            logger.info(f"Time taken to read {self.fits_file}: {elapsed_time:.2f} s")
 
 
 def load_all_eigenspectra(data_path):
@@ -273,6 +272,7 @@ def load_all_eigenspectra(data_path):
     if not os.path.exists(data_path):
         raise FileNotFoundError(f"Path not found: {data_path}")
 
+    start_time = time.time()
     data_path = Path(data_path)
 
     # Determine if path is a file or directory
@@ -327,9 +327,10 @@ def load_all_eigenspectra(data_path):
     if len(nmf_dict) == 0:
         raise ValueError(f"No eigenspectra FITS files loaded from {data_path}")
 
+    elapsed_time = time.time() - start_time
     logger.info(
         f"Successfully loaded {files_loaded} eigenspectra file(s) with {len(nmf_dict)} "
-        f"redshift bins"
+        f"redshift bins. Time took: {elapsed_time:.2f} s"
     )
 
     return nmf_dict
@@ -468,5 +469,5 @@ class ContinuumSpec:
 
         if self.verbose:
             elapsed_time = time.time() - start_time
-            print(f"INFO: Time taken to read {self.fits_file}: {elapsed_time:.2f} s")
+            logger.info(f"Time taken to read {self.fits_file}: {elapsed_time:.2f} s")
 

--- a/nmfqsofit/io.py
+++ b/nmfqsofit/io.py
@@ -330,7 +330,7 @@ def load_all_eigenspectra(data_path):
     elapsed_time = time.time() - start_time
     logger.info(
         f"Successfully loaded {files_loaded} eigenspectra file(s) with {len(nmf_dict)} "
-        f"redshift bins. Time took: {elapsed_time:.2f} s"
+        f"redshift bins. Time taken: {elapsed_time:.2f} s"
     )
 
     return nmf_dict

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -19,7 +19,7 @@ from .utils import interpolation1D
 from .logger import get_logger
 
 logger = get_logger(__name__)
-LARGE_CHI2 = 999999.0  #for failure cases
+LARGE_CHI2 = 999999.0  # for failure cases
 
 @dataclass(frozen=True)
 class Eigenset:
@@ -391,7 +391,7 @@ class NMFContinuum:
             logger.debug(f'fit_coeff_iterative iter={ntr}: sigma={sigma:.4f}, n_masked={n_changed}')
 
             if n_changed == 0:
-                logger.info(f'fit_coeff_iterative: converged (no new masked pixels) after iteration {ntr}')
+                logger.debug(f'fit_coeff_iterative: converged (no new masked pixels) after iteration {ntr}')
                 break
 
             coeff, model = self._run_solver(A_interp, flux_fit, ivar_fit, good)
@@ -459,7 +459,10 @@ class NMFContinuum:
 
         cont0 = np.asarray(first_continuum)
 
-        if kernel_large < 0 or kernel_small < 0:
+        if kernel_large is None or kernel_small is None:
+            kernel_large = None
+            kernel_small = None
+        elif kernel_large < 0 or kernel_small < 0:
             kernel_large = None
             kernel_small = None
 
@@ -505,6 +508,9 @@ class NMFContinuum:
             sigma_pre = self._mad_sigma(delta_pre[ok_pre])
             if np.isfinite(sigma_pre) and (sigma_pre > 0.0):
                 good = ok_pre & (delta_pre > -nsigma * sigma_pre)
+
+        if kernel_large is None or kernel_small is None:
+            return cont0 * smooth
 
         for it in range(int(smoothing_niter)):
 
@@ -599,7 +605,7 @@ class NMFContinuum:
             # Coverage: valid pixels within the eigenset's observed-frame wavelength range
             obs_min = eig.rest_wave.min() * (1.0 + self.z)
             obs_max = eig.rest_wave.max() * (1.0 + self.z)
-            mask_coverage = np.isfinite(self.flux) & np.isfinite(self.ivar) & (self.ivar > 0) & (self.wave >= obs_min) & (self.wave <= obs_max)
+            mask_coverage = self.mask & np.isfinite(self.wave) & (self.wave >= obs_min) & (self.wave <= obs_max)
             coverage = int(np.count_nonzero(mask_coverage))
 
             # Skip if norm is not usable
@@ -623,6 +629,7 @@ class NMFContinuum:
                     "z[%.2f, %.2f) lam[%.1f, %.1f] stat=%s; skipping this configuration",
                     self.z, zmin, zmax, lam_min, lam_max, stat
                 )
+                continue
 
             # Scale first-pass continuum back to OBSERVED units
             first_cont_obs = first_cont_norm * norm
@@ -639,7 +646,9 @@ class NMFContinuum:
                 cost = first_cost
                 cont_obs = first_cont_obs.copy()
 
-            if coverage >= best["coverage"]:
+            if coverage > best["coverage"] or (
+                coverage == best["coverage"] and cost < best["final_cost"]
+            ):
                 best.update(
                     {
                         "final_cost": cost,

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -377,8 +377,7 @@ class NMFContinuum:
             pull[ok] = (flux_fit[ok] - model[ok]) * np.sqrt(ivar_fit[ok])
 
             # Estimate sigma from emission-side pixels only (pull > 0).
-            # These are unaffected by absorption and give the true noise level,
-            # avoiding the inflated sigma that results from including absorbed pixels.
+
             above = pull[ok & (pull > 0.0)]
             sigma = self._mad_sigma(above) if above.size >= 2 else self._mad_sigma(pull[ok])
             if not np.isfinite(sigma) or sigma <= 0.0:
@@ -438,8 +437,7 @@ class NMFContinuum:
         Notes:
         - This correction is performed in observed space (same grid as flux).
         - The masking uses a robust sigma estimate (MAD) on (r - smooth_ratio).
-        - Pixels with ivar <= 0, non-finite flux/ivar, or non-positive continuum
-            are excluded from the correction.
+        - Pixels with ivar <= 0, non-finite flux/ivar, or non-positive continuum are excluded from the correction.
 
         Args:
             flux (np.ndarray): Observed flux array (nwave,).
@@ -486,9 +484,9 @@ class NMFContinuum:
         good = good0.copy()
         smooth = np.ones_like(cont0, dtype=float)
 
-        # Pre-masking: run a single coarse median filter pass on the raw ratio to
-        # identify absorption dips before the iterative loop begins.  This ensures
-        # that even iteration 0 does not feed absorber pixels into medfilt.
+        # Pre-masking: run a single coarse median filter pass on the raw ratio to identify absorption dips before the iterative
+        # loop begins.
+
         if (kernel_large is not None) and (kernel_large > 0):
             r_pre = self._neutral_fill(ratio)
             r_pre[~good0] = 1.0
@@ -509,7 +507,7 @@ class NMFContinuum:
 
             prev_good = good.copy()
 
-            # Fill masked/invalid pixels with 1.0 (neutral value) before medfilt
+            # Fill masked/invalid pixels with 1.0 before medfilt
             r_fill = self._neutral_fill(ratio)
             r_fill[~good] = 1.0
 
@@ -525,7 +523,7 @@ class NMFContinuum:
 
             smooth = r1 * r2
 
-            # Robust masking against narrow absorption spikes in ratio space
+            # Robust masking against narrow absorption features in ratio space
             delta = np.full_like(ratio, np.nan, dtype=float)
             ok = good0 & np.isfinite(ratio) & np.isfinite(smooth) & (smooth > 0)
             delta[ok] = ratio[ok] / smooth[ok] - 1.0

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -277,7 +277,7 @@ class NMFContinuum:
         """
         good = self.mask & np.isfinite(model_obs)
         n = int(np.count_nonzero(good)) - n_comp  #degrees of freedome
-        if n == 0:
+        if n <= 0:
             return np.inf
 
         diff = self.flux[good] - model_obs[good]
@@ -617,8 +617,12 @@ class NMFContinuum:
             # Fit coefficients in normalized space (with iterative absorption rejection)
             try:
                 coeff, first_cont_norm = self._fit_coeff_iterative(A_interp, flux_fit, ivar_fit, mask_fit)
-            except Exception:
-                continue
+            except Exception as exc:
+                logger.exception(
+                    "Exception during coefficient fitting at z=%.4f for eigenset "
+                    "z[%.2f, %.2f) lam[%.1f, %.1f] stat=%s; skipping this configuration",
+                    self.z, zmin, zmax, lam_min, lam_max, stat
+                )
 
             # Scale first-pass continuum back to OBSERVED units
             first_cont_obs = first_cont_norm * norm
@@ -635,7 +639,7 @@ class NMFContinuum:
                 cost = first_cost
                 cont_obs = first_cont_obs.copy()
 
-            if coverage > best["coverage"]:
+            if coverage >= best["coverage"]:
                 best.update(
                     {
                         "final_cost": cost,

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -19,7 +19,7 @@ from .utils import interpolation1D
 from .logger import get_logger
 
 logger = get_logger(__name__)
-LARGE_CHI2 = 999999.0
+LARGE_CHI2 = 999999.0  #for failure cases
 
 @dataclass(frozen=True)
 class Eigenset:
@@ -276,7 +276,7 @@ class NMFContinuum:
             float: Reduced chi^2 value.
         """
         good = self.mask & np.isfinite(model_obs)
-        n = int(np.count_nonzero(good)) - n_comp
+        n = int(np.count_nonzero(good)) - n_comp  #degrees of freedome
         if n == 0:
             return np.inf
 
@@ -344,7 +344,7 @@ class NMFContinuum:
         return coeff, model
 
     def _run_solver(self, A_interp, flux_fit, ivar_fit, good):
-        """Dispatch to the configured solver (nnls or nmf)."""
+        """Run solver (nnls or nmf)."""
         if self.method == "nnls":
             return self._fit_coeff_nnls(A_interp, flux_fit, ivar_fit, good)
         return self._fit_coeff_nmf(A_interp, flux_fit, ivar_fit, good)
@@ -354,9 +354,9 @@ class NMFContinuum:
         Iterative sigma-rejection wrapper around the coefficient solver.
 
         Performs an initial fit, then repeats up to fit_niter rounds of
-        downward sigma rejection (absorption masking) followed by a refit.
+        absorption masking using sigma clipping followed by a refit.
         Only pixels with pull < -fit_nsigma * sigma are masked, so emission
-        features on the other side are never excluded.
+        features stay as they are.
 
         Args:
             A_interp (np.ndarray): Interpolated eigenspectra matrix (ncomp, nwave).
@@ -370,25 +370,28 @@ class NMFContinuum:
         good = mask_fit.copy()
         coeff, model = self._run_solver(A_interp, flux_fit, ivar_fit, good)
 
-        for _ in range(self.fit_niter):
-            # Normalized residuals (pull) at currently accepted pixels
+        for ntr in range(self.fit_niter):
+            # Normalized residuals at currently accepted pixels
             pull = np.full_like(flux_fit, np.nan)
             ok = good & np.isfinite(model) & (ivar_fit > 0)
             pull[ok] = (flux_fit[ok] - model[ok]) * np.sqrt(ivar_fit[ok])
 
-            # Estimate sigma from emission-side pixels only (pull > 0).
+            # Estimate sigma from emission-side pixels only.
 
             above = pull[ok & (pull > 0.0)]
             sigma = self._mad_sigma(above) if above.size >= 2 else self._mad_sigma(pull[ok])
             if not np.isfinite(sigma) or sigma <= 0.0:
                 break
 
-            # Mask only downward outliers (absorption pixels)
+            # Mask only potential absorption pixels
             new_good = good & np.where(np.isfinite(pull), pull > -self.fit_nsigma * sigma, True)
             n_changed = int(np.count_nonzero(new_good != good))
             good = new_good
 
+            logger.debug(f'fit_coeff_iterative iter={ntr}: sigma={sigma:.4f}, n_masked={n_changed}')
+
             if n_changed == 0:
+                logger.info(f'fit_coeff_iterative: converged (no new masked pixels) after iteration {ntr}')
                 break
 
             coeff, model = self._run_solver(A_interp, flux_fit, ivar_fit, good)
@@ -435,7 +438,7 @@ class NMFContinuum:
             continuum_final = first_continuum * smooth_ratio
 
         Notes:
-        - This correction is performed in observed space (same grid as flux).
+        - This correction is performed in observed frame (same grid as flux).
         - The masking uses a robust sigma estimate (MAD) on (r - smooth_ratio).
         - Pixels with ivar <= 0, non-finite flux/ivar, or non-positive continuum are excluded from the correction.
 
@@ -468,7 +471,7 @@ class NMFContinuum:
             if kernel_small % 2 == 0:
                 raise ValueError("kernel_small must be odd")
 
-        # Base validity mask
+        # Valid pixels mask
         good0 = (
             np.isfinite(self.flux)
             & np.isfinite(self.ivar)
@@ -477,15 +480,15 @@ class NMFContinuum:
             & (cont0 > 0.0)
         )
 
-        # Ratio in observed space
+        # Ratio in observed frame
         ratio = np.full_like(cont0, np.nan, dtype=float)
         ratio[good0] = self.flux[good0] / cont0[good0]
 
         good = good0.copy()
         smooth = np.ones_like(cont0, dtype=float)
 
-        # Pre-masking: run a single coarse median filter pass on the raw ratio to identify absorption dips before the iterative
-        # loop begins.
+        # Pre-masking: run a single coarse median filter pass on the raw ratio
+        # to identify absorption dips before the iterative loop begins.
 
         if (kernel_large is not None) and (kernel_large > 0):
             r_pre = self._neutral_fill(ratio)
@@ -523,7 +526,7 @@ class NMFContinuum:
 
             smooth = r1 * r2
 
-            # Robust masking against narrow absorption features in ratio space
+            # Robust masking against narrow absorption features in ratio
             delta = np.full_like(ratio, np.nan, dtype=float)
             ok = good0 & np.isfinite(ratio) & np.isfinite(smooth) & (smooth > 0)
             delta[ok] = ratio[ok] / smooth[ok] - 1.0
@@ -564,7 +567,8 @@ class NMFContinuum:
             "zmax": None,
             "norm": None,
             "n_comp": None,
-            "method": self.method
+            "method": self.method,
+            "coverage": -1,
         }
 
         # Keep observed arrays fixed (do not mutate self.flux/ivar)
@@ -591,6 +595,12 @@ class NMFContinuum:
                 lam_max_obs=lam_max_obs,
                 stat=stat,
             )
+
+            # Coverage: valid pixels within the eigenset's observed-frame wavelength range
+            obs_min = eig.rest_wave.min() * (1.0 + self.z)
+            obs_max = eig.rest_wave.max() * (1.0 + self.z)
+            mask_coverage = np.isfinite(self.flux) & np.isfinite(self.ivar) & (self.ivar > 0) & (self.wave >= obs_min) & (self.wave <= obs_max)
+            coverage = int(np.count_nonzero(mask_coverage))
 
             # Skip if norm is not usable
             if (not np.isfinite(norm)) or (norm <=0.0):
@@ -625,7 +635,7 @@ class NMFContinuum:
                 cost = first_cost
                 cont_obs = first_cont_obs.copy()
 
-            if cost < best["final_cost"]:
+            if coverage > best["coverage"]:
                 best.update(
                     {
                         "final_cost": cost,
@@ -636,7 +646,8 @@ class NMFContinuum:
                         "zmin": zmin,
                         "zmax": zmax,
                         "norm": norm,
-                        "n_comp": n_comp
+                        "n_comp": n_comp,
+                        "coverage": coverage,
                     }
                 )
 
@@ -645,7 +656,7 @@ class NMFContinuum:
             first_eig = next(iter(self.eigenspectra_dict.values()))
             ncomp = first_eig['eigvec'].shape[0] if isinstance(first_eig, dict) else first_eig.eigvec.shape[0]
 
-            # Initialize all outputs with zero values
+            # Initialize all outputs with zero values and chi2 would be very large for failure cases
             best["coefficients"] = np.zeros(ncomp)
             best["first_continuum"] = np.zeros(self.wave.size)
             best["continuum"] = np.zeros(self.wave.size)

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -20,6 +20,7 @@ from .logger import get_logger
 
 logger = get_logger(__name__)
 LARGE_CHI2 = 999999.0  # for failure cases
+MIN_PIXELS_FOR_NORM = 5  # minimum valid pixels required to compute normalization factor
 
 @dataclass(frozen=True)
 class Eigenset:
@@ -65,7 +66,7 @@ def compute_normalization(
         & (ivar > 0.0)
     )
 
-    if int(np.count_nonzero(sel)) < 5:
+    if int(np.count_nonzero(sel)) < MIN_PIXELS_FOR_NORM:
         return np.nan
 
     if stat == "median":

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -122,7 +122,9 @@ class NMFContinuum:
         method: str,
         maxiters: int,
         smoothing_niter: int,
-        interp_kind: str
+        interp_kind: str,
+        fit_niter: int = 3,
+        fit_nsigma: float = 3.0,
     ):
         """
         Initialize NMFContinuum fitter.
@@ -145,6 +147,8 @@ class NMFContinuum:
         self.maxiters = maxiters
         self.smoothing_niter = smoothing_niter
         self.interp_kind = interp_kind
+        self.fit_niter = int(fit_niter)
+        self.fit_nsigma = float(fit_nsigma)
 
         self.delta_lambda = np.nanmedian(self.wave[1:] - self.wave[:-1])
 
@@ -263,7 +267,7 @@ class NMFContinuum:
 
     def _chi2_reduced_against_observed(self, model_obs: np.ndarray, n_comp: int) -> float:
         """
-        Reduced chi^2 computed against the observed spectrum using observed ivar/mask.
+        Reduced chi^2 computed against the observed spectrum using all valid pixels.
 
         Args:
             model_obs (np.ndarray): Model flux in observed units (nwave,).
@@ -339,12 +343,88 @@ class NMFContinuum:
         model = coeff @ A_interp
         return coeff, model
 
-    def _apply_smooth_correction(self, first_continuum, kernel_large, kernel_small, smoothing_niter, nsigma=1.5):
+    def _run_solver(self, A_interp, flux_fit, ivar_fit, good):
+        """Dispatch to the configured solver (nnls or nmf)."""
+        if self.method == "nnls":
+            return self._fit_coeff_nnls(A_interp, flux_fit, ivar_fit, good)
+        return self._fit_coeff_nmf(A_interp, flux_fit, ivar_fit, good)
+
+    def _fit_coeff_iterative(self, A_interp: np.ndarray, flux_fit: np.ndarray, ivar_fit: np.ndarray, mask_fit: np.ndarray):
+        """
+        Iterative sigma-rejection wrapper around the coefficient solver.
+
+        Performs an initial fit, then repeats up to fit_niter rounds of
+        downward sigma rejection (absorption masking) followed by a refit.
+        Only pixels with pull < -fit_nsigma * sigma are masked, so emission
+        features on the other side are never excluded.
+
+        Args:
+            A_interp (np.ndarray): Interpolated eigenspectra matrix (ncomp, nwave).
+            flux_fit (np.ndarray): Normalized flux to fit (nwave,).
+            ivar_fit (np.ndarray): Normalized inverse variance (nwave,).
+            mask_fit (np.ndarray): Boolean mask for valid pixels (nwave,).
+
+        Returns:
+            tuple: (coeff, model) from the final iteration.
+        """
+        good = mask_fit.copy()
+        coeff, model = self._run_solver(A_interp, flux_fit, ivar_fit, good)
+
+        for _ in range(self.fit_niter):
+            # Normalized residuals (pull) at currently accepted pixels
+            pull = np.full_like(flux_fit, np.nan)
+            ok = good & np.isfinite(model) & (ivar_fit > 0)
+            pull[ok] = (flux_fit[ok] - model[ok]) * np.sqrt(ivar_fit[ok])
+
+            # Estimate sigma from emission-side pixels only (pull > 0).
+            # These are unaffected by absorption and give the true noise level,
+            # avoiding the inflated sigma that results from including absorbed pixels.
+            above = pull[ok & (pull > 0.0)]
+            sigma = self._mad_sigma(above) if above.size >= 2 else self._mad_sigma(pull[ok])
+            if not np.isfinite(sigma) or sigma <= 0.0:
+                break
+
+            # Mask only downward outliers (absorption pixels)
+            new_good = good & np.where(np.isfinite(pull), pull > -self.fit_nsigma * sigma, True)
+            n_changed = int(np.count_nonzero(new_good != good))
+            good = new_good
+
+            if n_changed == 0:
+                break
+
+            coeff, model = self._run_solver(A_interp, flux_fit, ivar_fit, good)
+
+        return coeff, model
+
+    @staticmethod
+    def _neutral_fill(arr: np.ndarray) -> np.ndarray:
+        """Return a copy of arr with non-finite values replaced by 1.0."""
+        out = arr.copy()
+        out[~np.isfinite(out)] = 1.0
+        return out
+
+    @staticmethod
+    def _mad_sigma(arr: np.ndarray) -> float:
+        """Robust sigma estimate via Median Absolute Deviation (MAD).
+
+        sigma_MAD = 1.4826 * median(|x - median(x)|)
+
+        NaN values are ignored.  Returns np.nan if fewer than 2 finite values.
+        """
+        finite = arr[np.isfinite(arr)]
+        if finite.size < 2:
+            return np.nan
+        return 1.4826 * float(np.median(np.abs(finite - np.median(finite))))
+
+    def _apply_smooth_correction(self, first_continuum, kernel_large, kernel_small, smoothing_niter, nsigma=0.5):
 
         """Apply iterative median-filter correction to remove intermediate
         and small scale fluctuations.
 
         This implements the idea described in Zhu (e.g., Zhu & Ménard 2013/2016):
+        0) Pre-masking: apply a single coarse median filter (kernel_large) to the
+            raw ratio to identify and mask absorption dips before the main loop,
+            so that even the first iteration does not feed absorber pixels into medfilt.
         1) Construct the ratio r = flux / first_continuum.
         2) Smooth r with an intermediate-scale median filter (kernel_large).
         3) Remove smaller-scale power with an additional median filter (kernel_small).
@@ -406,26 +486,41 @@ class NMFContinuum:
         good = good0.copy()
         smooth = np.ones_like(cont0, dtype=float)
 
+        # Pre-masking: run a single coarse median filter pass on the raw ratio to
+        # identify absorption dips before the iterative loop begins.  This ensures
+        # that even iteration 0 does not feed absorber pixels into medfilt.
+        if (kernel_large is not None) and (kernel_large > 0):
+            r_pre = self._neutral_fill(ratio)
+            r_pre[~good0] = 1.0
+
+            r_smooth_pre = medfilt(r_pre, kernel_size=kernel_large)
+            r_smooth_pre = self._neutral_fill(r_smooth_pre)
+            r_smooth_pre[r_smooth_pre <= 0.0] = 1.0
+
+            delta_pre = np.full_like(ratio, np.nan)
+            ok_pre = good0 & np.isfinite(ratio) & (r_smooth_pre > 0)
+            delta_pre[ok_pre] = ratio[ok_pre] / r_smooth_pre[ok_pre] - 1.0
+
+            sigma_pre = self._mad_sigma(delta_pre[ok_pre])
+            if np.isfinite(sigma_pre) and (sigma_pre > 0.0):
+                good = ok_pre & (delta_pre > -nsigma * sigma_pre)
+
         for it in range(int(smoothing_niter)):
 
             prev_good = good.copy()
 
-            # Fill invalid points with neutral value to allow medfilt
-            r = ratio.copy()
-            r[~good] = np.nan
-
-            r_fill = r.copy()
-            r_fill[~np.isfinite(r_fill)] = 1.0
+            # Fill masked/invalid pixels with 1.0 (neutral value) before medfilt
+            r_fill = self._neutral_fill(ratio)
+            r_fill[~good] = 1.0
 
             # Intermediate-scale smoothing
             r1 = medfilt(r_fill, kernel_size=kernel_large)
-            r1[~np.isfinite(r1)] = 1.0
+            r1 = self._neutral_fill(r1)
             r1[r1 <= 0.0] = 1.0
 
             # Small-scale smoothing on residual ratio
-            r_small = r_fill / r1
-            r2 = medfilt(r_small, kernel_size=kernel_small)
-            r2[~np.isfinite(r2)] = 1.0
+            r2 = medfilt(r_fill / r1, kernel_size=kernel_small)
+            r2 = self._neutral_fill(r2)
             r2[r2 <= 0.0] = 1.0
 
             smooth = r1 * r2
@@ -436,8 +531,7 @@ class NMFContinuum:
             delta[ok] = ratio[ok] / smooth[ok] - 1.0
 
             # Use MAD sigma for absorber masking
-            #sigma = self._mad_sigma(delta[good])
-            sigma = np.nanstd(delta[good])
+            sigma = self._mad_sigma(delta[good])
             if (not np.isfinite(sigma)) or (sigma <= 0.0):
                 break
 
@@ -461,7 +555,7 @@ class NMFContinuum:
         if match_idx.size == 0:
             logger.warning(f"QSO (redshift: {self.z}) is outside NMF eigenspectra range.")
 
-        
+
         best = {
             "final_cost": LARGE_CHI2,
             "coefficients": None,
@@ -512,28 +606,26 @@ class NMFContinuum:
             ivar_fit = ivar_obs * (norm ** 2)
             mask_fit = np.isfinite(flux_fit) & np.isfinite(ivar_fit) & (ivar_fit > 0)
 
-            # Fit coefficients in normalized space
+            # Fit coefficients in normalized space (with iterative absorption rejection)
             try:
-                if self.method == "nnls":
-                    coeff, first_cont_norm = self._fit_coeff_nnls(A_interp, flux_fit, ivar_fit, mask_fit)
-                else:
-                    coeff, first_cont_norm = self._fit_coeff_nmf(A_interp, flux_fit, ivar_fit, mask_fit)
+                coeff, first_cont_norm = self._fit_coeff_iterative(A_interp, flux_fit, ivar_fit, mask_fit)
             except Exception:
                 continue
 
             # Scale first-pass continuum back to OBSERVED units
             first_cont_obs = first_cont_norm * norm
 
-            # Costs must be against observed spectrum
-            first_cost = self._chi2_reduced_against_observed(first_cont_obs, n_comp)
-
             # Smooth correction in observed units (uses self.flux/self.mask which are observed)
             cont_obs = self._apply_smooth_correction(first_cont_obs, kernel_large=self.kernel_large, kernel_small=self.kernel_small, smoothing_niter=self.smoothing_niter)
+
+            # Chi2 on all valid pixels for both continua
+            first_cost = self._chi2_reduced_against_observed(first_cont_obs, n_comp)
             cost = self._chi2_reduced_against_observed(cont_obs, n_comp)
 
+            # Keep smooth-corrected continuum only if it improves chi2
             if cost > first_cost:
-                cost = first_cost # not changing the cost
-                cont_obs = first_cont_obs.copy() # not changing the continnum
+                cost = first_cost
+                cont_obs = first_cont_obs.copy()
 
             if cost < best["final_cost"]:
                 best.update(
@@ -594,7 +686,7 @@ def _process_one(args):
     Returns:
         tuple: (coeff, first_continuum, continuum, first_cost, cost, eigvec_range, norm)
     """
-    wave, flux1, ivar1, z1, eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter = args
+    wave, flux1, ivar1, z1, eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter, fit_niter, fit_nsigma = args
     fitter = NMFContinuum(
         wave=wave,
         flux=flux1,
@@ -606,7 +698,9 @@ def _process_one(args):
         method=method,
         maxiters=maxiters,
         interp_kind=interp_kind,
-        smoothing_niter=smoothing_niter
+        smoothing_niter=smoothing_niter,
+        fit_niter=fit_niter,
+        fit_nsigma=fit_nsigma,
     )
     fitter.fit()
 
@@ -636,7 +730,9 @@ def run_parallel_continuum(
     n_jobs: int = -1,
     maxiters: int = 100,
     interp_kind: str = "linear",
-    smoothing_niter: str = 3
+    smoothing_niter: int = 3,
+    fit_niter: int = 3,
+    fit_nsigma: float = 3.0,
 ):
     """
     Fit continua for many QSOs in parallel.
@@ -654,6 +750,8 @@ def run_parallel_continuum(
         maxiters (int): Maximum iterations for solver (default: 100).
         interp_kind (str): Interpolation method for eigenspectra ('linear' or 'nearest'; default: 'linear').
         smoothing_niter (int): Maximum iteration for median filtering
+        fit_niter (int): Number of sigma-rejection iterations during coefficient fitting (default: 3).
+        fit_nsigma (float): Sigma threshold for absorption masking during fitting (default: 3.0).
 
     Returns:
         tuple:
@@ -683,7 +781,7 @@ def run_parallel_continuum(
     n_jobs = int(max(1, n_jobs))
 
     tasks = [
-        (wave, flux[i], ivar[i], float(z[i].item()), eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter)
+        (wave, flux[i], ivar[i], float(z[i].item()), eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter, fit_niter, fit_nsigma)
         for i in range(nqso)
     ]
 
@@ -713,7 +811,7 @@ def run_parallel_continuum(
     first_cost = np.asarray(first_cost_list, dtype=np.float32)
     final_cost = np.asarray(cost_list, dtype=np.float32)
 
-    eigvec_range = np.asarray(range_list, dtype="S8")
+    eigvec_range = np.asarray(range_list, dtype="S12")
     zmins = np.asarray(zmin_list, dtype=np.float32)
     zmaxs = np.asarray(zmax_list, dtype=np.float32)
 

--- a/nmfqsofit/nmfcontinuum.py
+++ b/nmfqsofit/nmfcontinuum.py
@@ -125,6 +125,7 @@ class NMFContinuum:
         interp_kind: str,
         fit_niter: int = 3,
         fit_nsigma: float = 3.0,
+        smooth_nsigma: float = 3.0,
     ):
         """
         Initialize NMFContinuum fitter.
@@ -149,6 +150,7 @@ class NMFContinuum:
         self.interp_kind = interp_kind
         self.fit_niter = int(fit_niter)
         self.fit_nsigma = float(fit_nsigma)
+        self.smooth_nsigma = float(smooth_nsigma)
 
         self.delta_lambda = np.nanmedian(self.wave[1:] - self.wave[:-1])
 
@@ -418,7 +420,7 @@ class NMFContinuum:
             return np.nan
         return 1.4826 * float(np.median(np.abs(finite - np.median(finite))))
 
-    def _apply_smooth_correction(self, first_continuum, kernel_large, kernel_small, smoothing_niter, nsigma=0.5):
+    def _apply_smooth_correction(self, first_continuum, kernel_large, kernel_small, smoothing_niter, nsigma=3.0):
 
         """Apply iterative median-filter correction to remove intermediate
         and small scale fluctuations.
@@ -635,7 +637,7 @@ class NMFContinuum:
             first_cont_obs = first_cont_norm * norm
 
             # Smooth correction in observed units (uses self.flux/self.mask which are observed)
-            cont_obs = self._apply_smooth_correction(first_cont_obs, kernel_large=self.kernel_large, kernel_small=self.kernel_small, smoothing_niter=self.smoothing_niter)
+            cont_obs = self._apply_smooth_correction(first_cont_obs, kernel_large=self.kernel_large, kernel_small=self.kernel_small, smoothing_niter=self.smoothing_niter, nsigma=self.smooth_nsigma)
 
             # Chi2 on all valid pixels for both continua
             first_cost = self._chi2_reduced_against_observed(first_cont_obs, n_comp)
@@ -646,6 +648,7 @@ class NMFContinuum:
                 cost = first_cost
                 cont_obs = first_cont_obs.copy()
 
+            # Select the best solution by maximum coverage; break ties by lowest chi2
             if coverage > best["coverage"] or (
                 coverage == best["coverage"] and cost < best["final_cost"]
             ):
@@ -708,7 +711,7 @@ def _process_one(args):
     Returns:
         tuple: (coeff, first_continuum, continuum, first_cost, cost, eigvec_range, norm)
     """
-    wave, flux1, ivar1, z1, eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter, fit_niter, fit_nsigma = args
+    wave, flux1, ivar1, z1, eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter, fit_niter, fit_nsigma, smooth_nsigma = args
     fitter = NMFContinuum(
         wave=wave,
         flux=flux1,
@@ -723,6 +726,7 @@ def _process_one(args):
         smoothing_niter=smoothing_niter,
         fit_niter=fit_niter,
         fit_nsigma=fit_nsigma,
+        smooth_nsigma=smooth_nsigma,
     )
     fitter.fit()
 
@@ -755,6 +759,7 @@ def run_parallel_continuum(
     smoothing_niter: int = 3,
     fit_niter: int = 3,
     fit_nsigma: float = 3.0,
+    smooth_nsigma: float = 3.0,
 ):
     """
     Fit continua for many QSOs in parallel.
@@ -774,6 +779,7 @@ def run_parallel_continuum(
         smoothing_niter (int): Maximum iteration for median filtering
         fit_niter (int): Number of sigma-rejection iterations during coefficient fitting (default: 3).
         fit_nsigma (float): Sigma threshold for absorption masking during fitting (default: 3.0).
+        smooth_nsigma (float): Sigma threshold for absorption masking during smoothing correction (default: 3.0).
 
     Returns:
         tuple:
@@ -803,7 +809,7 @@ def run_parallel_continuum(
     n_jobs = int(max(1, n_jobs))
 
     tasks = [
-        (wave, flux[i], ivar[i], float(z[i].item()), eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter, fit_niter, fit_nsigma)
+        (wave, flux[i], ivar[i], float(z[i].item()), eigenspectra, kernel_large, kernel_small, method, maxiters, interp_kind, smoothing_niter, fit_niter, fit_nsigma, smooth_nsigma)
         for i in range(nqso)
     ]
 

--- a/nmfqsofit/parallel_main.py
+++ b/nmfqsofit/parallel_main.py
@@ -140,9 +140,9 @@ def main():
     if args.config:
         with open(args.config, 'r') as f:
             config = yaml.safe_load(f)
-        # Apply config values to args
+        # Apply config values to args (normalize hyphens to underscores to match argparse)
         for key, value in config.items():
-            setattr(args, key, value)
+            setattr(args, key.replace('-', '_'), value)
 
     # Validate that required arguments are present
     required_args = ['spectra_file', 'eigenspectra', 'output']

--- a/nmfqsofit/parallel_main.py
+++ b/nmfqsofit/parallel_main.py
@@ -33,6 +33,13 @@ def main():
     parser = argparse.ArgumentParser(description="NMF Continuum Estimation (Parallel)")
 
     parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="YAML config file with all arguments. If provided, command-line arguments are ignored.",
+    )
+
+    parser.add_argument(
         "--spectra-file",
         type=str,
         required=False,
@@ -127,12 +134,6 @@ def main():
         default=None,
         help="Extra FITS headers to include in KEY=VALUE format.",
     )
-    parser.add_argument(
-        "--config",
-        type=str,
-        default=None,
-        help="YAML config file with all arguments. If provided, command-line arguments are ignored.",
-    )
 
     args = parser.parse_args()
 
@@ -159,10 +160,10 @@ def main():
     if args.kernel_small %2 == 0:
         args.kernel_small+=1 # just make it odd
 
-    logger.info("==== USER PROVIDED ARGUMENTS ====")
+    logger.info("\n==== USER PROVIDED ARGUMENTS ====\n")
     for key, value in vars(args).items():
         logger.info(f"{key}: {value}")
-    logger.info("================================")
+    print("\n================================\n")
 
     # Determine number/selection of QSOs
     if args.n_qso is None:

--- a/nmfqsofit/parallel_main.py
+++ b/nmfqsofit/parallel_main.py
@@ -50,7 +50,7 @@ def main():
     parser.add_argument(
         "--ncpus",
         type=int,
-        default=8,
+        default=4,
         help="Number of CPU processes to use (default: 8).",
     )
     parser.add_argument(
@@ -98,6 +98,20 @@ def main():
         type=int,
         default=3,
         help="number of maximum iteration for median filtering (default 3)",
+    )
+
+    parser.add_argument(
+        "--fit-niter",
+        type=int,
+        default=1,
+        help="number of sigma-rejection iterations during coefficient fitting (default 1; set to 0 for no rejection).",
+    )
+
+    parser.add_argument(
+        "--fit-nsigma",
+        type=float,
+        default=3.0,
+        help="sigma threshold for absorption masking during coefficient fitting (default 3.0)",
     )
 
     parser.add_argument(
@@ -202,7 +216,9 @@ def main():
             n_jobs=n_jobs,
             maxiters=args.maxiters,
             interp_kind=args.interp_kind,
-            smoothing_niter=args.smoothing_niter
+            smoothing_niter=args.smoothing_niter,
+            fit_niter=args.fit_niter,
+            fit_nsigma=args.fit_nsigma,
         )
     )
 

--- a/nmfqsofit/parallel_main.py
+++ b/nmfqsofit/parallel_main.py
@@ -36,7 +36,7 @@ def main():
         "--config",
         type=str,
         default=None,
-        help="YAML config file with all arguments. If provided, command-line arguments are ignored.",
+        help="YAML config file with all arguments. If provided, config values override CLI defaults.",
     )
 
     parser.add_argument(
@@ -58,7 +58,7 @@ def main():
         "--ncpus",
         type=int,
         default=4,
-        help="Number of CPU processes to use (default: 8).",
+        help="Number of CPU processes to use (default: 4).",
     )
     parser.add_argument(
         "--n-qso",
@@ -110,8 +110,8 @@ def main():
     parser.add_argument(
         "--fit-niter",
         type=int,
-        default=1,
-        help="number of sigma-rejection iterations during coefficient fitting (default 1; set to 0 for no rejection).",
+        default=3,
+        help="number of sigma-rejection iterations during coefficient fitting (default 3; set to 0 for no rejection).",
     )
 
     parser.add_argument(
@@ -131,7 +131,7 @@ def main():
         "--headers",
         type=str,
         nargs="+",
-        default=None,
+        default=[],
         help="Extra FITS headers to include in KEY=VALUE format.",
     )
 
@@ -163,7 +163,7 @@ def main():
     logger.info("\n==== USER PROVIDED ARGUMENTS ====\n")
     for key, value in vars(args).items():
         logger.info(f"{key}: {value}")
-    print("\n================================\n")
+    logger.info("\n================================\n")
 
     # Determine number/selection of QSOs
     if args.n_qso is None:

--- a/nmfqsofit/parallel_main.py
+++ b/nmfqsofit/parallel_main.py
@@ -36,7 +36,7 @@ def main():
         "--config",
         type=str,
         default=None,
-        help="YAML config file with all arguments. If provided, config values override CLI defaults.",
+        help="YAML config file with all arguments. If provided, values from this file override all command-line arguments (including explicitly provided ones)..",
     )
 
     parser.add_argument(

--- a/nmfqsofit/parallel_main.py
+++ b/nmfqsofit/parallel_main.py
@@ -75,7 +75,13 @@ def main():
         "--kernel-size",
         type=int,
         default=141,
-        help="Median filter kernel size (odd integer; default: 141).",
+        help="Median filter kernel size for intermediate-scale smoothing (odd integer; default: 141).",
+    )
+    parser.add_argument(
+        "--kernel-small",
+        type=int,
+        default=71,
+        help="Median filter kernel size for small-scale smoothing (odd integer; default: 71, half of --kernel-size, rounded up to odd).",
     )
     parser.add_argument(
         "--method",
@@ -122,6 +128,13 @@ def main():
     )
 
     parser.add_argument(
+        "--smooth-nsigma",
+        type=float,
+        default=1.5,
+        help="sigma threshold for absorption masking during smoothing correction (default 1.5)",
+    )
+
+    parser.add_argument(
         "--output",
         type=str,
         required=False,
@@ -155,10 +168,10 @@ def main():
     # Setup logging
     logger = setup_logger("nmfqsofit", level=logging.INFO)
 
-    args.kernel_small = int(args.kernel_size / 2)
-
-    if args.kernel_small %2 == 0:
-        args.kernel_small+=1 # just make it odd
+    if args.kernel_small is None:
+        args.kernel_small = int(args.kernel_size / 2)
+        if args.kernel_small % 2 == 0:
+            args.kernel_small += 1  # ensure odd
 
     logger.info("\n==== USER PROVIDED ARGUMENTS ====\n")
     for key, value in vars(args).items():
@@ -220,6 +233,7 @@ def main():
             smoothing_niter=args.smoothing_niter,
             fit_niter=args.fit_niter,
             fit_nsigma=args.fit_nsigma,
+            smooth_nsigma=args.smooth_nsigma,
         )
     )
 

--- a/nmfqsofit/utils.py
+++ b/nmfqsofit/utils.py
@@ -301,6 +301,7 @@ def _parse_headers(args):
     headers["FILT_ITR"] = (int(args.smoothing_niter), 'Number of iterations for median filtering')
     headers["SIG_CLIP"] = (float(args.fit_nsigma), 'Sigma clipping  (N * sigma), to mask absorption')
     headers["FIT_ITER"] = (int(args.fit_niter), 'Number of iterations for sigma clipping')
+    headers["SM_SIGMA"] = (float(args.smooth_nsigma), 'Sigma clipping (N * sigma) for smoothing correction')
 
     for k, (pkg, ver) in enumerate(versions.items()):
         headers[f"DEPNAM{k:02d}"] = str(pkg)

--- a/nmfqsofit/utils.py
+++ b/nmfqsofit/utils.py
@@ -299,6 +299,8 @@ def _parse_headers(args):
 
     headers["MAXITER"] = (maxiters_value, 'Maximum iteration for fitting (None means default as used solvers)')
     headers["FILT_ITR"] = (int(args.smoothing_niter), 'Number of iterations for median filtering')
+    headers["SIG_CLIP"] = (int(args.fit_nsigma), 'Sigma clipping (N) during fitting (N * sigma), to mask absorption pixels')
+    headers["FIT_ITER"] = (int(args.fit_niter), 'Number of itereations for sigma clipping during fitting')
 
     for k, (pkg, ver) in enumerate(versions.items()):
         headers[f"DEPNAM{k:02d}"] = str(pkg)

--- a/nmfqsofit/utils.py
+++ b/nmfqsofit/utils.py
@@ -282,8 +282,8 @@ def _parse_headers(args):
                 versions[pkg] = 'not installed'
 
     headers["METHOD"] = (str(args.method) , 'Fitting Method')
-    headers["EIGSPEC"] = (str(args.eigenspectra) , 'Eigenvector directory')
-    headers["KERN_I"] = (int(args.kernel_size), 'kernel size for removing intermediate fluctuation')
+    headers["EIGENVEC"] = (str(args.eigenspectra))
+    headers["KERN_I"] = (int(args.kernel_size), 'kernel size for removing large fluctuation')
     headers["KERN_II"] = (int(args.kernel_small), 'kernel size for removing small fluctuation')
 
     # while still validating other invalid values with a clear error.
@@ -297,10 +297,10 @@ def _parse_headers(args):
                 f"Invalid value for maxiters: {args.maxiters!r}. Expected an integer or null."
             ) from exc
 
-    headers["MAXITER"] = (maxiters_value, 'Maximum iteration for fitting (None means default as used solvers)')
+    headers["MAXITER"] = (maxiters_value, 'Maximum iteration for solver fitting')
     headers["FILT_ITR"] = (int(args.smoothing_niter), 'Number of iterations for median filtering')
-    headers["SIG_CLIP"] = (int(args.fit_nsigma), 'Sigma clipping (N) during fitting (N * sigma), to mask absorption pixels')
-    headers["FIT_ITER"] = (int(args.fit_niter), 'Number of itereations for sigma clipping during fitting')
+    headers["SIG_CLIP"] = (int(args.fit_nsigma), 'Sigma clipping  (N * sigma), to mask absorption')
+    headers["FIT_ITER"] = (int(args.fit_niter), 'Number of itereations for sigma clipping')
 
     for k, (pkg, ver) in enumerate(versions.items()):
         headers[f"DEPNAM{k:02d}"] = str(pkg)

--- a/nmfqsofit/utils.py
+++ b/nmfqsofit/utils.py
@@ -282,7 +282,7 @@ def _parse_headers(args):
                 versions[pkg] = 'not installed'
 
     headers["METHOD"] = (str(args.method) , 'Fitting Method')
-    headers["EIGENVEC"] = (str(args.eigenspectra))
+    headers["EIGENVEC"] = (str(args.eigenspectra), 'Eigenvector (eigenspectra) configuration')
     headers["KERN_I"] = (int(args.kernel_size), 'kernel size for removing large fluctuation')
     headers["KERN_II"] = (int(args.kernel_small), 'kernel size for removing small fluctuation')
 
@@ -299,8 +299,8 @@ def _parse_headers(args):
 
     headers["MAXITER"] = (maxiters_value, 'Maximum iteration for solver fitting')
     headers["FILT_ITR"] = (int(args.smoothing_niter), 'Number of iterations for median filtering')
-    headers["SIG_CLIP"] = (int(args.fit_nsigma), 'Sigma clipping  (N * sigma), to mask absorption')
-    headers["FIT_ITER"] = (int(args.fit_niter), 'Number of itereations for sigma clipping')
+    headers["SIG_CLIP"] = (float(args.fit_nsigma), 'Sigma clipping  (N * sigma), to mask absorption')
+    headers["FIT_ITER"] = (int(args.fit_niter), 'Number of iterations for sigma clipping')
 
     for k, (pkg, ver) in enumerate(versions.items()):
         headers[f"DEPNAM{k:02d}"] = str(pkg)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     },
     author='Abhijeet Anand',
     author_email='abhijeetanand2011@gmail.com',
-    description='Nonnegative matrix factorization based continuum fitting for Quasars using vectorized NMF module or NNLS methods',
+    description='Quasar continuum fitter using vectorized NMF module or NNLS method, with parallel processing support.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/abhi0395/nmfqsofit',
@@ -34,5 +34,5 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
-    python_requires='>=3.9',
+    python_requires='>=3.10',
 )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -434,17 +434,10 @@ class TestContinuumSpec(unittest.TestCase):
             spec.read_fits()
 
     def test_verbose_prints_timing(self):
-        import io as _io
-        import sys
-        captured = _io.StringIO()
-        old_out = sys.stdout
-        sys.stdout = captured
-        try:
+        import logging
+        with self.assertLogs("nmfqsofit.io", level="INFO") as cm:
             spec = ContinuumSpec(self.path, autoload=True, verbose=True)
-        finally:
-            sys.stdout = old_out
-        output = captured.getvalue()
-        self.assertIn("Time taken", output)
+        self.assertTrue(any("Time taken" in msg for msg in cm.output))
 
     def test_with_index(self):
         spec = ContinuumSpec(self.path, index=0, autoload=True, verbose=False)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -434,7 +434,6 @@ class TestContinuumSpec(unittest.TestCase):
             spec.read_fits()
 
     def test_verbose_prints_timing(self):
-        import logging
         with self.assertLogs("nmfqsofit.io", level="INFO") as cm:
             spec = ContinuumSpec(self.path, autoload=True, verbose=True)
         self.assertTrue(any("Time taken" in msg for msg in cm.output))

--- a/tests/test_nmfcontinuum.py
+++ b/tests/test_nmfcontinuum.py
@@ -102,7 +102,7 @@ class TestNMFContinuum(unittest.TestCase):
         self.assertEqual(out["final_cost"].shape, (n_take,))
         self.assertEqual(out["eigvector_range"].shape, (n_take,))
         self.assertEqual(out["norm_factor"].shape, (n_take,))
-        # z and related arrays may include an extra singleton dimension; only length is important
+        # z and related arrays may include an extra dimension; only length is important
         self.assertEqual(out["z"].shape[0], n_take)
         self.assertEqual(out["zmin"].shape[0], n_take)
         self.assertEqual(out["zmax"].shape[0], n_take)
@@ -154,7 +154,7 @@ class TestNMFContinuum(unittest.TestCase):
         self.assertEqual(out["final_cost"].shape, (n_take,))
         self.assertEqual(out["eigvector_range"].shape, (n_take,))
         self.assertEqual(out["norm_factor"].shape, (n_take,))
-        # account for possible singleton trailing dimension on z
+        # account for possible dimension on z
         self.assertEqual(out["z"].shape[0], n_take)
         self.assertEqual(out["zmin"].shape[0], n_take)
         self.assertEqual(out["zmax"].shape[0], n_take)

--- a/tests/test_nmfcontinuum_unit.py
+++ b/tests/test_nmfcontinuum_unit.py
@@ -440,5 +440,150 @@ class TestRunParallelContinuumValidation(unittest.TestCase):
         self.assertEqual(out["coefficients"].shape[0], 2)
 
 
+# ---------------------------------------------------------------------------
+# Tests for _fit_coeff_iterative
+# ---------------------------------------------------------------------------
+
+class TestFitCoeffIterative(unittest.TestCase):
+    """Tests for iterative sigma-rejection in coefficient fitting."""
+
+    def setUp(self):
+        self.fitter = _make_fitter(n_wave=200, n_comp=3)
+        key = list(self.fitter.eigenspectra_dict.keys())[0]
+        item = self.fitter.eigenspectra_dict[key]
+        eig = Eigenset(
+            rest_wave=np.asarray(item["wave"]),
+            eigvec=np.asarray(item["eigvec"]),
+        )
+        self.A = self.fitter._interpolate_eigvec_to_observed(eig)
+
+    def test_returns_nonneg_coefficients(self):
+        flux_fit = self.fitter.flux / 2.0
+        ivar_fit = self.fitter.ivar
+        mask_fit = self.fitter.mask
+        coeff, model = self.fitter._fit_coeff_iterative(
+            self.A, flux_fit, ivar_fit, mask_fit
+        )
+        self.assertEqual(coeff.shape, (3,))
+        self.assertTrue(np.all(coeff >= 0))
+        self.assertEqual(model.shape, (self.fitter.wave.size,))
+
+    def test_absorption_pixels_masked_do_not_change_emission(self):
+        """Inject a deep absorption trough and verify the fit is not pulled down."""
+        rng = np.random.default_rng(0)
+        n = self.fitter.wave.size
+        flux_clean = np.full(n, 2.0)
+
+        # Build a model from the clean fit first
+        mask_fit = self.fitter.mask.copy()
+        ivar_fit = self.fitter.ivar.copy()
+        coeff_clean, model_clean = self.fitter._fit_coeff_iterative(
+            self.A, flux_clean, ivar_fit, mask_fit
+        )
+
+        # Add a narrow deep absorption trough at the centre
+        flux_abs = flux_clean.copy()
+        mid = n // 2
+        flux_abs[mid - 5 : mid + 5] = 0.0  # strong absorption
+
+        coeff_abs, model_abs = self.fitter._fit_coeff_iterative(
+            self.A, flux_abs, ivar_fit, mask_fit
+        )
+        # Coefficients from the absorption-masked fit should be close to the
+        # clean fit because the absorber pixels are sigma-clipped away.
+        np.testing.assert_allclose(coeff_abs, coeff_clean, rtol=0.5)
+
+    def test_zero_niter_skips_rejection(self):
+        """With fit_niter=0 only the initial fit is run; absorption pixels stay."""
+        self.fitter.fit_niter = 0
+        n = self.fitter.wave.size
+        flux_fit = np.full(n, 2.0)
+        ivar_fit = self.fitter.ivar.copy()
+        mask_fit = self.fitter.mask.copy()
+        coeff, model = self.fitter._fit_coeff_iterative(
+            self.A, flux_fit, ivar_fit, mask_fit
+        )
+        # Should still return valid arrays
+        self.assertEqual(coeff.shape, (3,))
+        self.assertTrue(np.all(np.isfinite(model)))
+
+    def test_all_pixels_masked_raises(self):
+        """If the mask leaves fewer pixels than components, solver must raise."""
+        mask_fit = np.zeros(self.fitter.wave.size, dtype=bool)
+        with self.assertRaises(ValueError):
+            self.fitter._fit_coeff_iterative(
+                self.A, self.fitter.flux, self.fitter.ivar, mask_fit
+            )
+
+    def test_output_model_finite(self):
+        flux_fit = self.fitter.flux / 2.0
+        coeff, model = self.fitter._fit_coeff_iterative(
+            self.A, flux_fit, self.fitter.ivar, self.fitter.mask
+        )
+        self.assertTrue(np.all(np.isfinite(model)))
+
+
+# ---------------------------------------------------------------------------
+# Additional tests for _apply_smooth_correction
+# ---------------------------------------------------------------------------
+
+class TestApplySmoothCorrectionExtra(unittest.TestCase):
+    """Tests for edge cases and behaviour of the smoothing correction."""
+
+    def setUp(self):
+        self.fitter = _make_fitter(n_wave=300, kernel_large=21, kernel_small=11)
+
+    def test_none_kernel_returns_first_continuum_unchanged(self):
+        """Passing None kernels must bypass all smoothing and return cont0 * 1."""
+        first_cont = np.full(300, 3.0)
+        result = self.fitter._apply_smooth_correction(
+            first_cont, kernel_large=None, kernel_small=None, smoothing_niter=3
+        )
+        np.testing.assert_allclose(result, first_cont)
+
+    def test_smoothing_does_not_amplify_continuum(self):
+        """Output should be in a reasonable range relative to the input."""
+        first_cont = np.full(300, 2.0)
+        result = self.fitter._apply_smooth_correction(
+            first_cont, kernel_large=21, kernel_small=11, smoothing_niter=3
+        )
+        # Smooth ratio should be ≈1 when flux ≈ continuum; output ≈ input
+        np.testing.assert_allclose(result, first_cont, rtol=0.5)
+
+    def test_absorption_trough_does_not_pull_continuum_down(self):
+        """With a narrow absorption trough in the flux, the corrected continuum
+        should not be significantly lower than the absorption-free value."""
+        n = 300
+        # Flat flux and continuum at 2.0 everywhere
+        self.fitter.flux = np.full(n, 2.0)
+        self.fitter.ivar = np.ones(n)
+        self.fitter.mask = np.ones(n, dtype=bool)
+
+        first_cont = np.full(n, 2.0)
+
+        # Inject a deep absorption trough into flux
+        mid = n // 2
+        self.fitter.flux[mid - 5 : mid + 5] = 0.1
+
+        result = self.fitter._apply_smooth_correction(
+            first_cont, kernel_large=21, kernel_small=11, smoothing_niter=3
+        )
+        # Outside the trough the continuum should remain close to 2.0
+        outside_trough = np.ones(n, dtype=bool)
+        outside_trough[mid - 15 : mid + 15] = False
+        self.assertTrue(
+            np.all(result[outside_trough] > 1.5),
+            "Smoothing correction pulled the continuum below 1.5 outside the trough",
+        )
+
+    def test_zero_smoothing_niter_returns_first_continuum(self):
+        """With smoothing_niter=0 the loop never runs; smooth stays all-ones."""
+        first_cont = np.full(300, 2.0)
+        result = self.fitter._apply_smooth_correction(
+            first_cont, kernel_large=21, kernel_small=11, smoothing_niter=0
+        )
+        np.testing.assert_allclose(result, first_cont)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,6 +191,7 @@ class TestParseHeaders(unittest.TestCase):
         args.smoothing_niter = 3
         args.fit_nsigma = 3
         args.fit_niter = 3
+        args.smooth_nsigma = 3.0
         return args
 
     def test_basic_parse(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -189,6 +189,8 @@ class TestParseHeaders(unittest.TestCase):
         args.kernel_small = 71
         args.maxiters = 100
         args.smoothing_niter = 3
+        args.fit_nsigma = 3
+        args.fit_niter = 3
         return args
 
     def test_basic_parse(self):
@@ -197,7 +199,7 @@ class TestParseHeaders(unittest.TestCase):
         self.assertEqual(result["SURVEY"], "SDSS")
         self.assertEqual(result["RELEASE"], "DR16")
         self.assertIn("METHOD", result)
-        self.assertIn("EIGSPEC", result)
+        self.assertIn("EIGENVEC", result)
 
     def test_invalid_header_no_equals_raises(self):
         args = self._make_args(headers=["BADHEADER"])


### PR DESCRIPTION
## PR summary

This PR addresses the issue raised in #2 .

### Main changes

- Coefficient fitting now uses iterative sigma-clipping to mask absorption dips during the fit. This prevents the continuum model from being pulled downward simply to reduce the overall chi^2.
- Eigenspectra-set selection is no longer based on chi^2 minimization. Instead, the selected eigenspectra bin is the one that provides the largest number of valid pixels for a given quasar.
- This change is important because chi^2-based selection can bias the solution toward fitting real absorption features, since capturing absorption dips can artificially lower the chi^2.
- The fitting and masking steps are now performed iteratively.

### New CLI arguments

Two new fitting-related CLI arguments have been added:

- `--fit-niter`: Number of iterative sigma-rejection passes during coefficient fitting
- `--fit-nsigma`: Downward sigma threshold used to reject absorption dips during fitting
- `--kernel-small`: Median filter kernel size for small-scale smoothing 
- `--smooth-nsigma`: sigma threshold for absorption masking during smoothing correction

### Minor cleanup

- Removed redundant printed output
- Added more timing information to several functions
- Updated the README
- Updated the citation information
- Made output headers more compatible with FITS requirements